### PR TITLE
Use get_phantom_base_url instead of 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
 **dedicated_custom_list** | optional | string | Specify the name of the custom list that will be used as the data record for Fuse Box |
 **retention_limit** | optional | numeric | The number of days to retain records in the list. If Fuse Box runs slower than expected, lower retention |
-**https_port** | optional | string | Splunk SOAR HTTPS port if your instance uses one other than 443 |
 **debug** | optional | boolean | Print debugging statements to log |
 
 ### Supported Actions

--- a/fusebox.json
+++ b/fusebox.json
@@ -38,20 +38,13 @@
             "name": "retention_limit",
             "id": 1
         },
-        "https_port": {
-            "description": "Splunk SOAR HTTPS port if your instance uses one other than 443",
-            "data_type": "string",
-            "order": 2,
-            "name": "https_port",
-            "id": 2
-        },
         "debug": {
             "description": "Print debugging statements to log",
             "data_type": "boolean",
             "default": false,
-            "order": 3,
+            "order": 2,
             "name": "debug",
-            "id": 3
+            "id": 2
         }
     },
     "actions": [

--- a/fusebox.json
+++ b/fusebox.json
@@ -129,11 +129,5 @@
             "output": [],
             "versions": "EQ(*)"
         }
-    ],
-    "custom_made": true,
-    "directory": "fusebox_fad3cfec-b8a0-4a0c-9579-c26bb4abde3a",
-    "version": 1,
-    "appname": "-",
-    "executable": "spawn3",
-    "disabled": false
+    ]
 }

--- a/fusebox_connector.py
+++ b/fusebox_connector.py
@@ -14,9 +14,11 @@
 # and limitations under the License.
 import json
 import time
+import urllib.parse
 from datetime import datetime, timedelta
 
 import phantom.app as phantom
+import phantom.rules as phrules
 from phantom.action_result import ActionResult
 
 
@@ -47,12 +49,9 @@ class FuseBoxConnector(phantom.BaseConnector):
 
     def _get_base_url(self):
         self.__print("_get_base_url()", True)
-        port = 443
-        try:
-            port = self.get_config()["https_port"]
-        except:
-            pass
-        return f"https://127.0.0.1:{port}"
+        rest_url = phrules.build_phantom_rest_url()
+        scheme, netloc, _, _, _ = urllib.parse.urlsplit(rest_url)
+        return urllib.parse.urlunsplit((scheme, netloc, '', '', ''))
 
     def _get_list_data(self, list_name):
         self.__print("_get_list_data()", True)

--- a/fusebox_connector.py
+++ b/fusebox_connector.py
@@ -14,11 +14,9 @@
 # and limitations under the License.
 import json
 import time
-import urllib.parse
 from datetime import datetime, timedelta
 
 import phantom.app as phantom
-import phantom.rules as phrules
 from phantom.action_result import ActionResult
 
 
@@ -49,9 +47,7 @@ class FuseBoxConnector(phantom.BaseConnector):
 
     def _get_base_url(self):
         self.__print("_get_base_url()", True)
-        rest_url = phrules.build_phantom_rest_url()
-        scheme, netloc, _, _, _ = urllib.parse.urlsplit(rest_url)
-        return urllib.parse.urlunsplit((scheme, netloc, "", "", ""))
+        return self.get_phantom_base_url()
 
     def _get_list_data(self, list_name):
         self.__print("_get_list_data()", True)

--- a/fusebox_connector.py
+++ b/fusebox_connector.py
@@ -51,7 +51,7 @@ class FuseBoxConnector(phantom.BaseConnector):
         self.__print("_get_base_url()", True)
         rest_url = phrules.build_phantom_rest_url()
         scheme, netloc, _, _, _ = urllib.parse.urlsplit(rest_url)
-        return urllib.parse.urlunsplit((scheme, netloc, '', '', ''))
+        return urllib.parse.urlunsplit((scheme, netloc, "", "", ""))
 
     def _get_list_data(self, list_name):
         self.__print("_get_list_data()", True)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
-* Use build_phantom_rest_url instead of 127.0.0.1
+* Use get_phantom_base_url instead of 127.0.0.1

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,3 @@
 **Unreleased**
 
-* chore(ci): update pre-commit config
 * Use get_phantom_base_url instead of 127.0.0.1

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Use build_phantom_rest_url instead of 127.0.0.1


### PR DESCRIPTION
### Bug Fixes
- Fixes SOARHELP-4541 by removing the hard-coded 127.0.0.1

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
